### PR TITLE
avoid shell interpretting variables in 2020-09-15-vscode-git.md

### DIFF
--- a/_posts/2020-09-15-vscode-git.md
+++ b/_posts/2020-09-15-vscode-git.md
@@ -166,7 +166,7 @@ To do it from the command-line:
 
 ```bash
 git config --global merge.tool vscode
-git config --global mergetool.vscode.cmd "code --wait $MERGED"
+git config --global mergetool.vscode.cmd 'code --wait $MERGED'
 ```
 
 You can add the following to your global Git config if you prefer:


### PR DESCRIPTION
The original results in:

```
[mergetool "vscode"]
	cmd = "code --wait "
```